### PR TITLE
📦 improve MetricCollection serde for SecureModem

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -21,8 +21,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 Portions of this software are copyright of their respective authors and released under the MIT license:
- - lua-object-model, Copyright 2015 Pavel Batečko (Shira). For licensing see src/telem/lib/LICENSE-ObjectModel.txt
- - ECNet2, Copyright 2020 Miguel Oliveira. For licensing see src/telem/vendor/LICENSE-ECNet2.txt
  - CCryptoLib, Copyright 2023 Miguel Oliveira. For licensing see src/telem/vendor/LICENSE-CCryptoLib.txt
- - RedRun, By JackMacWindows. For licensing see src/telem/vendor/redrun.lua
+ - ECNet2, Copyright 2020 Miguel Oliveira. For licensing see src/telem/vendor/LICENSE-ECNet2.txt
+ - lualzw, Copyright 2016 Rochet2. For licensing see src/telem/vendor/lualzw.lua
+ - lua-object-model, Copyright 2015 Pavel Batečko (Shira). For licensing see src/telem/lib/LICENSE-ObjectModel.txt
  - Plotter, Copyright 2023 Daniel Marcolesco. For licensing see src/telem/vendor/LICENSE-Plotter.txt
+ - RedRun, By JackMacWindows. For licensing see src/telem/vendor/redrun.lua

--- a/src/telem/init.lua
+++ b/src/telem/init.lua
@@ -1,9 +1,9 @@
 -- Telem by cyberbit
 -- MIT License
--- Version 0.4.2
+-- Version 0.5.0
 
 local _Telem = {
-    _VERSION = '0.4.2',
+    _VERSION = '0.5.0',
     util = require 'telem.lib.util',
     input = require 'telem.lib.input',
     output = require 'telem.lib.output',

--- a/src/telem/lib/Metric.lua
+++ b/src/telem/lib/Metric.lua
@@ -39,4 +39,32 @@ function Metric:__tostring ()
     return label .. unit .. adapter .. source
 end
 
+function Metric.pack (self)
+    return {
+        n = self.name,
+        v = self.value,
+        u = self.unit,
+        s = self.source,
+        a = self.adapter,
+    }
+end
+
+function Metric.unpack (data)
+    return Metric({
+        name = data.n,
+        value = data.v,
+        unit = data.u,
+        source = data.s,
+        adapter = data.a
+    })
+end
+
+function Metric.serialize (self)
+    return textutils.serialize(self:pack(), { compact = true })
+end
+
+function Metric.unserialize (data)
+    return Metric.unpack(textutils.unserialize(data))
+end
+
 return Metric

--- a/src/telem/lib/MetricCollection.lua
+++ b/src/telem/lib/MetricCollection.lua
@@ -31,7 +31,7 @@ function MetricCollection:insert (element)
 end
 
 function MetricCollection:setContext (ctx)
-    self.context = { table.unpack(ctx) }
+    self.context = ctx
 
     return self
 end
@@ -57,6 +57,141 @@ function MetricCollection:find (filter)
     end
 
     return nil
+end
+
+function MetricCollection.pack (self)
+    local packedMetrics = {}
+    local adapterLookup = {}
+    local sourceLookup = {}
+    local unitLookup = {}
+    local nameLookup = {
+        -- first name token
+        {},
+
+        -- second name token
+        {}
+    }
+
+    for _,v in ipairs(self.metrics) do
+        local packed = v:pack()
+
+        -- create name tokens
+        local nameTokens = {}
+
+        for token in (packed.n .. ':'):gmatch('([^:]*):') do
+            table.insert(nameTokens, token)
+        end
+
+        local t1 = nameTokens[1]
+        local t2 = nameTokens[2]
+        local t3 = nameTokens[3]
+
+        if #nameTokens > 2 then
+            t3 = table.concat(nameTokens, ':', 3)
+        end
+
+        local n1, n2, nn
+
+        if t3 then
+            n1, n2, nn = t1, t2, t3
+        elseif t2 then
+            n1, n2, nn = t1, nil, t2
+        elseif t1 then
+            n1, n2, nn = nil, nil, t1
+        end
+
+        -- pull LUT
+        local ln1 = n1 and t.indexOf(nameLookup[1], n1)
+        local ln2 = n2 and t.indexOf(nameLookup[2], n2)
+        local la = t.indexOf(adapterLookup, packed.a)
+        local ls = t.indexOf(sourceLookup, packed.s)
+        local lu = t.indexOf(unitLookup, packed.u)
+
+        -- register missing LUT
+        if ln1 and ln1 < 0 then
+            table.insert(nameLookup[1], n1)
+
+            ln1 = #nameLookup[1]
+        end
+        if ln2 and ln2 < 0 then
+            table.insert(nameLookup[2], n2)
+
+            ln2 = #nameLookup[2]
+        end
+        if la < 0 then
+            table.insert(adapterLookup, packed.a)
+
+            la = #adapterLookup
+        end
+        if ls < 0 then
+            table.insert(sourceLookup, packed.s)
+
+            ls = #sourceLookup
+        end
+        if lu < 0 then
+            table.insert(unitLookup, packed.u)
+
+            lu = #unitLookup
+        end
+
+        local ln
+        if ln1 or ln2 then
+            ln = {ln1, ln2}
+        end
+
+        table.insert(packedMetrics, {
+            ln = ln,
+            n = nn,
+            v = packed.v,
+            la = la,
+            ls = ls,
+            lu = lu
+        })
+    end
+
+    return {
+        c = self.context,
+        ln = nameLookup,
+        la = adapterLookup,
+        ls = sourceLookup,
+        lu = unitLookup,
+        m = packedMetrics
+    }
+end
+
+function MetricCollection.unpack (data)
+    local undata = data
+
+    local nameLookup = undata.ln
+    local adapterLookup = undata.la
+    local sourceLookup = undata.ls
+    local unitLookup = undata.lu
+
+    local collection = MetricCollection()
+
+    for _, v in ipairs(undata.m) do
+        local nPrefix = ''
+
+        if v.ln then
+            for lni, lnv in ipairs(v.ln) do
+                nPrefix = nPrefix .. nameLookup[lni][lnv] .. ':'
+            end
+        end
+
+        local tempMetric = Metric{
+            name = nPrefix .. v.n,
+            value = v.v,
+            adapter = v.la and adapterLookup[v.la],
+            source = v.ls and sourceLookup[v.ls],
+            unit = v.lu and unitLookup[v.lu]
+        }
+
+        collection:insert(tempMetric)
+    end
+
+    collection:setContext(undata.c)
+
+    return collection
 end
 
 return MetricCollection

--- a/src/telem/lib/util.lua
+++ b/src/telem/lib/util.lua
@@ -112,6 +112,18 @@ local function constrainAppend (data, value, width)
     return removed
 end
 
+local function indexOf (tab, value)
+    if type(value) == 'nil' then return -1 end
+    
+    for i,v in ipairs(tab) do
+        if v == value then
+            return i
+        end
+    end
+
+    return -1
+end
+
 return {
     log = log,
     err = err,
@@ -121,4 +133,5 @@ return {
     shortnum = shortnum,
     shortnum2 = shortnum2,
     constrainAppend = constrainAppend,
+    indexOf = indexOf
 }

--- a/src/telem/vendor/init.lua
+++ b/src/telem/vendor/init.lua
@@ -1,6 +1,6 @@
 -- Telem Vendor Loader by cyberbit
 -- MIT License
--- Version 0.4.0
+-- Version 0.5.0
 -- Submodules are copyright of their respective authors. For licensing, see https://github.com/cyberbit/telem/blob/main/LICENSE
 
 if package.path:find('telem/vendor') == nil then package.path = package.path .. ';telem/vendor/?;telem/vendor/?.lua;telem/vendor/?/init.lua' end
@@ -8,11 +8,13 @@ if package.path:find('telem/vendor') == nil then package.path = package.path .. 
 local ecnet2 = require 'ecnet2'
 local random = require 'ccryptolib.random'
 local plotter = require 'plotter'
+local lualzw = require 'lualzw'
 
 return {
     ccryptolib = {
         random = random
     },
     ecnet2 = ecnet2,
+    lualzw = lualzw,
     plotter = plotter
 }

--- a/src/telem/vendor/lualzw.lua
+++ b/src/telem/vendor/lualzw.lua
@@ -1,0 +1,165 @@
+--[[
+MIT License
+
+Copyright (c) 2016 Rochet2
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+]]
+
+local char = string.char
+local type = type
+local select = select
+local sub = string.sub
+local tconcat = table.concat
+
+local basedictcompress = {}
+local basedictdecompress = {}
+for i = 0, 255 do
+    local ic, iic = char(i), char(i, 0)
+    basedictcompress[ic] = iic
+    basedictdecompress[iic] = ic
+end
+
+local function dictAddA(str, dict, a, b)
+    if a >= 256 then
+        a, b = 0, b+1
+        if b >= 256 then
+            dict = {}
+            b = 1
+        end
+    end
+    dict[str] = char(a,b)
+    a = a+1
+    return dict, a, b
+end
+
+local function compress(input)
+    if type(input) ~= "string" then
+        return nil, "string expected, got "..type(input)
+    end
+    local len = #input
+    if len <= 1 then
+        return "u"..input
+    end
+
+    local dict = {}
+    local a, b = 0, 1
+
+    local result = {"c"}
+    local resultlen = 1
+    local n = 2
+    local word = ""
+    for i = 1, len do
+        local c = sub(input, i, i)
+        local wc = word..c
+        if not (basedictcompress[wc] or dict[wc]) then
+            local write = basedictcompress[word] or dict[word]
+            if not write then
+                return nil, "algorithm error, could not fetch word"
+            end
+            result[n] = write
+            resultlen = resultlen + #write
+            n = n+1
+            if  len <= resultlen then
+                return "u"..input
+            end
+            dict, a, b = dictAddA(wc, dict, a, b)
+            word = c
+        else
+            word = wc
+        end
+    end
+    result[n] = basedictcompress[word] or dict[word]
+    resultlen = resultlen+#result[n]
+    n = n+1
+    if  len <= resultlen then
+        return "u"..input
+    end
+    return tconcat(result)
+end
+
+local function dictAddB(str, dict, a, b)
+    if a >= 256 then
+        a, b = 0, b+1
+        if b >= 256 then
+            dict = {}
+            b = 1
+        end
+    end
+    dict[char(a,b)] = str
+    a = a+1
+    return dict, a, b
+end
+
+local function decompress(input)
+    if type(input) ~= "string" then
+        return nil, "string expected, got "..type(input)
+    end
+
+    if #input < 1 then
+        return nil, "invalid input - not a compressed string"
+    end
+
+    local control = sub(input, 1, 1)
+    if control == "u" then
+        return sub(input, 2)
+    elseif control ~= "c" then
+        return nil, "invalid input - not a compressed string"
+    end
+    input = sub(input, 2)
+    local len = #input
+
+    if len < 2 then
+        return nil, "invalid input - not a compressed string"
+    end
+
+    local dict = {}
+    local a, b = 0, 1
+
+    local result = {}
+    local n = 1
+    local last = sub(input, 1, 2)
+    result[n] = basedictdecompress[last] or dict[last]
+    n = n+1
+    for i = 3, len, 2 do
+        local code = sub(input, i, i+1)
+        local lastStr = basedictdecompress[last] or dict[last]
+        if not lastStr then
+            return nil, "could not find last from dict. Invalid input?"
+        end
+        local toAdd = basedictdecompress[code] or dict[code]
+        if toAdd then
+            result[n] = toAdd
+            n = n+1
+            dict, a, b = dictAddB(lastStr..sub(toAdd, 1, 1), dict, a, b)
+        else
+            local tmp = lastStr..sub(lastStr, 1, 1)
+            result[n] = tmp
+            n = n+1
+            dict, a, b = dictAddB(tmp, dict, a, b)
+        end
+        last = code
+    end
+    return tconcat(result)
+end
+
+return {
+    compress = compress,
+    decompress = decompress,
+}


### PR DESCRIPTION
Fixes #36. SecureModem adapters will now use a custom serializer/deserializer (SerDe) to reduce footprint. For large MetricCollections, the string will additionally be LZW compressed for transport.