### PR TITLE
Add Advanced Peripherals Energy Detector InputAdapter

### DIFF
--- a/src/telem/lib/input.lua
+++ b/src/telem/lib/input.lua
@@ -16,7 +16,6 @@ return {
         fusionReactor = require 'telem.lib.input.mekanism.FusionReactorInputAdapter',
     },
 
-    -- or advanced_peripherals?
     advancedPeripherals = {
         energyDetector = require 'telem.lib.input.advancedPeripherals.EnergyDetectorInputAdapter',
     },

--- a/src/telem/lib/input.lua
+++ b/src/telem/lib/input.lua
@@ -16,6 +16,11 @@ return {
         fusionReactor = require 'telem.lib.input.mekanism.FusionReactorInputAdapter',
     },
 
+    -- or advanced_peripherals?
+    advancedPeripherals = {
+        energyDetector = require 'telem.lib.input.advancedPeripherals.EnergyDetectorInputAdapter',
+    },
+
     -- modem
     secureModem = require 'telem.lib.input.SecureModemInputAdapter'
 }

--- a/src/telem/lib/input/advancedPeripherals/BaseAdvancedPeripheralsInputAdapter.lua
+++ b/src/telem/lib/input/advancedPeripherals/BaseAdvancedPeripheralsInputAdapter.lua
@@ -1,0 +1,54 @@
+local o = require 'telem.lib.ObjectModel'
+
+local InputAdapter      = require 'telem.lib.InputAdapter'
+local Metric            = require 'telem.lib.Metric'
+local MetricCollection  = require 'telem.lib.MetricCollection'
+
+local BaseAdvancedPeripheralsAdapter = o.class(InputAdapter)
+BaseAdvancedPeripheralsAdapter.type = 'BaseAdvancedPeripheralsAdapter'
+
+function BaseAdvancedPeripheralsAdapter:constructor (peripheralName)
+    self:super('constructor')
+
+    self.prefix = 'ap:'
+
+    self.queries = {}
+
+    -- boot components
+    self:setBoot(function ()
+        self.components = {}
+
+        self:addComponentByPeripheralID(peripheralName)
+    end)()
+end
+
+local function queueHelper (results, index, query)
+    return function ()
+        results[index] = Metric(query:metricable():result())
+    end
+end
+
+function BaseAdvancedPeripheralsAdapter:read ()
+    self:boot()
+
+    local source, component = next(self.components)
+
+    local tempMetrics = {}
+    local queue = {}
+
+    for _, category in ipairs(self.categories) do
+        for k, v in pairs(self.queries[category]) do
+            table.insert(queue, queueHelper(
+                tempMetrics,
+                #queue + 1,
+                v:from(component):with('name', self.prefix .. k):with('source', source)
+            ))
+        end
+    end
+
+    parallel.waitForAll(table.unpack(queue))
+
+    return MetricCollection(table.unpack(tempMetrics))
+end
+
+return BaseAdvancedPeripheralsAdapter

--- a/src/telem/lib/input/advancedPeripherals/EnergyDetectorInputAdapter.lua
+++ b/src/telem/lib/input/advancedPeripherals/EnergyDetectorInputAdapter.lua
@@ -1,0 +1,37 @@
+local o = require 'telem.lib.ObjectModel'
+local t = require 'telem.lib.util'
+local fn = require 'telem.vendor'.fluent.fn
+
+local BaseAdvancedPeripheralsInputAdapter = require 'telem.lib.input.advancedPeripherals.BaseAdvancedPeripheralsInputAdapter'
+
+local EnergyDetectorInputAdapter = o.class(BaseAdvancedPeripheralsInputAdapter)
+EnergyDetectorInputAdapter.type = 'EnergyDetectorInputAdapter'
+
+function EnergyDetectorInputAdapter:constructor (peripheralName, categories)
+    self:super('constructor', peripheralName)
+
+    -- TODO this will be a configurable feature later
+    self.prefix = 'apenergy:'
+
+    -- TODO make these constants
+    local allCategories = {
+        'basic',
+    }
+
+    if not categories then
+        self.categories = { 'basic' }
+    elseif categories == '*' then
+        self.categories = allCategories
+    else
+        self.categories = categories
+    end
+
+    self.queries = {
+        basic = {
+            transfer_rate       = fn():call('getTransferRate'):energyRate(),
+            transfer_rate_limit = fn():call('getTransferRateLimit'):energyRate(),
+        }
+    }
+end
+
+return EnergyDetectorInputAdapter


### PR DESCRIPTION
This PR adds the Advanced Peripherals Energy Detector to the input adapters. The code is untested.

Closes #26 