### PR TITLE
Adapt chart line output to accept multiple filters

### DIFF
--- a/src/telem/lib/output.lua
+++ b/src/telem/lib/output.lua
@@ -14,7 +14,7 @@ return {
     -- Plotter
     plotter = {
         line = require 'telem.lib.output.plotter.ChartLineOutputAdapter',
-        multiline = require 'telem.lib.output.plotter.ChartMultiLineOutputAdapter',
+        multiLine = require 'telem.lib.output.plotter.ChartMultiLineOutputAdapter',
         area = require 'telem.lib.output.plotter.ChartAreaOutputAdapter',
     },
 

--- a/src/telem/lib/output.lua
+++ b/src/telem/lib/output.lua
@@ -14,6 +14,7 @@ return {
     -- Plotter
     plotter = {
         line = require 'telem.lib.output.plotter.ChartLineOutputAdapter',
+        multiline = require 'telem.lib.output.plotter.ChartMultiLineOutputAdapter',
         area = require 'telem.lib.output.plotter.ChartAreaOutputAdapter',
     },
 

--- a/src/telem/lib/output/plotter/ChartLineOutputAdapter.lua
+++ b/src/telem/lib/output/plotter/ChartLineOutputAdapter.lua
@@ -178,6 +178,11 @@ function ChartLineOutputAdapter:render ()
         if plotmin == nil then plotmin = math.huge end
         if plotmax == nil then plotmax = -math.huge end
 
+        if plotmin == math.huge then
+            actualPlotMin[i] = 0
+            actualPlotMax[i] = 0
+        end
+
         if plotmin == plotmax then
             plotmin = plotmin - minrange / 2
             plotmax = plotmax + minrange / 2

--- a/src/telem/lib/output/plotter/ChartMultiLineOutputAdapter.lua
+++ b/src/telem/lib/output/plotter/ChartMultiLineOutputAdapter.lua
@@ -78,23 +78,27 @@ end
 function ChartMultiLineOutputAdapter:write (collection)
     assert(o.instanceof(collection, MetricCollection), 'Collection must be a MetricCollection')
 
+    local maxDataRemoved = 0
+
     for i, metric in ipairs(self.filter) do
         local resultMetric = collection:find(metric.name)
         assert(resultMetric, 'could not find metric')
 
         -- TODO data width setting
-        self.gridOffsetX = self.gridOffsetX - t.constrainAppend(self.plotData[i], resultMetric and resultMetric.value or self.plotter.NAN, self.MAX_ENTRIES)
+        maxDataRemoved = math.max(maxDataRemoved, t.constrainAppend(self.plotData[i], resultMetric and resultMetric.value or self.plotter.NAN, self.MAX_ENTRIES))
+    end
 
-        -- TODO X_TICK setting
-        if self.gridOffsetX % self.X_TICK == 0 then
-            self.gridOffsetX = 0
-        end
+    self.gridOffsetX = self.gridOffsetX - maxDataRemoved
 
-        -- lazy layout update
-        local winw, winh = self.win.getSize()
-        if winw ~= self.plotter.box.term_width or winh ~= self.plotter.box.term_height then
-            self:updateLayout(true)
-        end
+    -- TODO X_TICK setting
+    if self.gridOffsetX % self.X_TICK == 0 then
+        self.gridOffsetX = 0
+    end
+
+    -- lazy layout update
+    local winw, winh = self.win.getSize()
+    if winw ~= self.plotter.box.term_width or winh ~= self.plotter.box.term_height then
+        self:updateLayout(true)
     end
 
     self:render()


### PR DESCRIPTION
As outlined in #77, this is my proposed API change for `ChartLineOutputAdapter.lua`. I also amended the filter structure to

```
{
    [1] = {
        name = 'my_metric',
        color = colors.red
    }
}
```

The only caveat so far is an error that pops up right at the start of series, apparently by a nil value in the plot data? I cannot figure out where it's coming from... It doesn't affect the output but if I can solve it, I will amend the PR.