### PR TITLE
feat: Graphite output adapter

### DIFF
--- a/src/telem/lib/output.lua
+++ b/src/telem/lib/output.lua
@@ -4,6 +4,7 @@ return {
 
     -- HTTP
     grafana = require 'telem.lib.output.GrafanaOutputAdapter',
+    graphite = require 'telem.lib.output.GraphiteOutputAdapter',
 
     -- Basalt
     basalt = {

--- a/src/telem/lib/output/GraphiteOutputAdapter.lua
+++ b/src/telem/lib/output/GraphiteOutputAdapter.lua
@@ -1,0 +1,63 @@
+local o                   = require 'telem.lib.ObjectModel'
+local OutputAdapter      = require 'telem.lib.OutputAdapter'
+local MetricCollection   = require 'telem.lib.MetricCollection'
+t
+local GraphiteOutputAdapter = o.class(OutputAdapter)
+GraphiteOutputAdapter.type = 'GraphiteOutputAdapter'
+
+-- Graphite Output Adapter
+--
+-- Endpoint: Grafana Cloud or hosted Graphite metric endpoint
+-- API Key: Token with at least metric:write scope
+--
+-- Note that API key are prefixed with a numeric, i.e. 2021620:your-api-key
+function GraphiteOutputAdapter:constructor(endpoint, apiKey)
+    self:super('constructor')
+    self.endpoint = assert(endpoint, 'Endpoint is required')
+    self.apiKey   = assert(apiKey,   'API key is required')
+end
+
+function GraphiteOutputAdapter:write(collection)
+    assert(o.instanceof(collection, MetricCollection),
+           'Collection must be a MetricCollection')
+
+    -- Build an array of metric objects
+    local payload = {}
+    -- Current unix timestamp
+    local now = math.floor(os.epoch('utc') / 1000)
+
+    for _, metric in pairs(collection.metrics) do
+        local tags = {}
+        if metric.unit    and metric.unit    ~= '' then table.insert(tags, 'unit='   .. metric.unit)    end
+        if metric.source  and metric.source  ~= '' then table.insert(tags, 'source=' .. metric.source)  end
+        if metric.adapter and metric.adapter ~= '' then table.insert(tags, 'adapter='.. metric.adapter) end
+        
+        -- Graphite metric name are namespaced by dots "."
+        local normalized_name = string.gsub(metric.name, ':', '.')
+
+        table.insert(payload, {
+            name     = normalized_name,
+            interval = 30,
+            value    = metric.value,
+            tags     = tags,
+            time     = metric.time or now,
+        })
+    end
+
+    -- Serialize to JSON
+    local body = textutils.serializeJSON(payload) 
+
+    -- POST to Graphite HTTP endpoint
+    local res = http.post{
+        url     = self.endpoint,
+        body    = body,
+        headers = {
+            ['Authorization'] = 'Bearer ' .. self.apiKey,
+            ['Content-Type']  = 'application/json',
+        }
+    }
+
+    return res
+end
+
+return GraphiteOutputAdapter

--- a/src/telem/lib/output/GraphiteOutputAdapter.lua
+++ b/src/telem/lib/output/GraphiteOutputAdapter.lua
@@ -58,8 +58,6 @@ function GraphiteOutputAdapter:write(collection)
             ['Content-Type']  = 'application/json',
         }
     }
-
-    return res
 end
 
 return GraphiteOutputAdapter

--- a/src/telem/lib/output/GraphiteOutputAdapter.lua
+++ b/src/telem/lib/output/GraphiteOutputAdapter.lua
@@ -1,7 +1,9 @@
-local o                   = require 'telem.lib.ObjectModel'
-local OutputAdapter      = require 'telem.lib.OutputAdapter'
-local MetricCollection   = require 'telem.lib.MetricCollection'
-t
+local o = require 'telem.lib.ObjectModel'
+local t = require 'telem.lib.util'
+
+local OutputAdapter     = require 'telem.lib.OutputAdapter'
+local MetricCollection  = require 'telem.lib.MetricCollection'
+
 local GraphiteOutputAdapter = o.class(OutputAdapter)
 GraphiteOutputAdapter.type = 'GraphiteOutputAdapter'
 


### PR DESCRIPTION
## Summary

Change adds [Graphite](https://graphiteapp.org/) as an output adapter.

Docs for the endpoint here: https://grafana.com/docs/grafana-cloud/send-data/metrics/metrics-graphite/http-api/#endpoints

## Motivation

Grafana Cloud doesn't have InfluxDB as a hosted data source, therefore the Grafana output adapter cannot be used with the cloud instance, and I was too lazy to setup my own InfluxDB + Telegraf for a Minecraft survival world.

But Grafana Cloud does support OTLP (Open Telemetry) or Graphite as options for its HTTP metric data connection.

## Tests

I minimally tested it locally on my Minecraft survival world, and the metrics are coming in.

## Notes

- Interval is hard-coded to 30 seconds, let me know if there's a way to get the cycle interval, but didn't look that much.